### PR TITLE
fix: increase language probability threshold

### DIFF
--- a/whisperx/asr.py
+++ b/whisperx/asr.py
@@ -301,7 +301,7 @@ class FasterWhisperPipeline(Pipeline):
         elif all(prob < self.language_probability_threshold for lang, prob in language_of_segment):
             print(
                 f"Warning: No language detected above threshold for {num_segments} segments. [language detection] "
-                f"Returning language of first segment {self.default_language}. {language_of_segment} [language detection]"
+                f"Returning language of first segment {language_of_segment[0][0]}. {language_of_segment} [language detection]"
             )
             return language_of_segment[0][0]
         


### PR DESCRIPTION
Increased threshold form 0.9 to 0.95.

Also:

- If no language above threshold is detected, then return language of first segment (previous default)
- If no language is detected at all, return preset default (sv)

[see linear ticket](https://linear.app/atglance/issue/BCK-144/increase-language-detection-threshold)